### PR TITLE
fix bug about killall

### DIFF
--- a/src/main/java/com/petuum/app/DeployTask.java
+++ b/src/main/java/com/petuum/app/DeployTask.java
@@ -74,7 +74,7 @@ public class DeployTask {
             {
                 sessionClient0 = session;
             }
-            String command = "killall -q java;cd " + remotePath +";export LD_LIBRARY_PATH=.:third_party/lib;java -classpath " + getClassPath()
+            String command = "killall -q petuum_ps;cd " + remotePath +";export LD_LIBRARY_PATH=.:third_party/lib:$LD_LIBRARY_PATH;exec -a petuum_ps java -classpath " + getClassPath()
                     + " " + mainClass + " " + client_id++ + " "+pathOfHostFile;
             session.execCommand(command);
         }


### PR DESCRIPTION
This is a minor commit. 
I have changed the process name as "petuum_ps" instead of "java". It won't kill other java programs.
