### PR TITLE
Python script to launch locally NMF enhanced:

### DIFF
--- a/app/NMF/script/run_local.py
+++ b/app/NMF/script/run_local.py
@@ -6,17 +6,17 @@ This script starts a process locally, using <client-id> <hostfile> as inputs.
 
 import os
 from os.path import dirname
-from os.path import join
 import time
 import sys
 
-if len(sys.argv) != 3:
+from optparse import OptionParser
+
+if len(sys.argv) < 3:
   print "usage: %s <client-id> <hostfile>" % sys.argv[0]
   sys.exit(1)
 
-# Please set the FULL app dir path here
+# app_dir is 2 dirs up from script (__file__) lofcation
 app_dir = dirname(dirname(os.path.realpath(__file__)))
-
 
 client_id = sys.argv[1]
 hostfile = sys.argv[2]
@@ -28,7 +28,7 @@ params = {
     , "load_cache": 0
     , "input_data_format": "text"
     , "output_data_format": "text"
-     , "output_path": join(app_dir, "sample/output")
+     , "output_path": os.path.join(app_dir, "sample/output")
     #, "output_path": "hdfs://hdfs-domain/user/bosen/dataset/nmf/sample/output"
     , "rank": 3
     , "m": 9
@@ -53,9 +53,9 @@ params = {
     , "init_R_high": 1.0
     , "table_staleness": 0
     , "maximum_running_time": 0.0
-     , "data_file": join(app_dir, "sample/data/sample.txt")
+     , "data_file": os.path.join(app_dir, "sample/data/sample.txt")
     #, "data_file": "hdfs://hdfs-domain/user/bosen/dataset/nmf/sample/data/sample.txt"
-    , "cache_path": join(app_dir, "N/A")
+    , "cache_path": os.path.join(app_dir, "N/A")
     }
 
 petuum_params = {
@@ -63,9 +63,8 @@ petuum_params = {
     "num_worker_threads": 4
     }
 
-build_dir = join(proj_dir, "build", "app", "NMF")
 prog_name = "nmf_main"
-prog_path = join(build_dir, prog_name)
+prog_path = os.path.join(app_dir, "bin", prog_name)
 
 hadoop_path = os.popen('hadoop classpath --glob').read()
 
@@ -75,21 +74,42 @@ env_params = (
   "GLOG_minloglevel=0 "
   )
 
-# Get host IPs
-with open(hostfile, "r") as f:
-  hostlines = f.read().splitlines()
-host_ips = [line.split()[1] for line in hostlines]
-petuum_params["num_clients"] = len(host_ips)
+def main ():
+    
+    parser = OptionParser()
+    parser.add_option("--is_partitioned", type=int, dest="is_partitioned", action="store", default=params["is_partitioned"])
+    parser.add_option("--n", type=int, dest="n", action="store", default=params["n"])
+    parser.add_option("--m", type=int, dest="m", action="store", default=params["m"])
+    parser.add_option("--data_file", type=str, dest="data_file", action="store", default=params["data_file"])
 
-cmd = "killall -q " + prog_name
-# os.system is synchronous call.
-os.system(cmd)
-print "Done killing"
+    
+    (options, args) = parser.parse_args() 
+    
+    option_dict = vars(options)
+    
+    for (k, v) in option_dict.items():
+        params[k] = v
+        
+    # Get host IPs
+    with open(hostfile, "r") as f:
+        hostlines = f.read().splitlines()
+        host_ips = [line.split()[1] for line in hostlines]
+        petuum_params["num_clients"] = len(host_ips)
+    
+    cmd = "killall -q " + prog_name
+    # os.system is synchronous call.
+    os.system(cmd)
+    print "Done killing"
+    
+    cmd = "export CLASSPATH=`hadoop classpath --glob`:$CLASSPATH; "
+    cmd += env_params + prog_path
+    petuum_params["client_id"] = client_id
+    cmd += "".join([" --%s=%s" % (k,v) for k,v in petuum_params.items()])
+    cmd += "".join([" --%s=%s" % (k,v) for k,v in params.items()])
+    print cmd
+    os.system(cmd)
+    
 
-cmd = "export CLASSPATH=`hadoop classpath --glob`:$CLASSPATH; "
-cmd += env_params + prog_path
-petuum_params["client_id"] = client_id
-cmd += "".join([" --%s=%s" % (k,v) for k,v in petuum_params.items()])
-cmd += "".join([" --%s=%s" % (k,v) for k,v in params.items()])
-print cmd
-os.system(cmd)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
   - accepts arguments to override predefined parameters
   - computes automatically the "project dir" (no more need to edit the file before testing the NMF application)
   - has a "main" function which lets "import" the script file in another python script

These changes helped me to create a tuned global launch script which passes the needed arguments to each worked without modifying the "run_local.py" script.

Mainly, the input file name is overwritten by the main script: in **partitioned mode**, each worker is launched with a sub-part of the global matrix (file name is suffixed with the worked ID)