### PR TITLE
Implement Accuracy Test in Multi-Stage Logistic Regression

### DIFF
--- a/app/mlr/src/abstract_mlr_sgd_solver.hpp
+++ b/app/mlr/src/abstract_mlr_sgd_solver.hpp
@@ -25,9 +25,14 @@ public:
   virtual std::vector<float> Predict(
       const petuum::ml::AbstractFeature<float>& feature) const = 0;
 
-  // Return 0 if a prediction (of length num_labels_) correctly gives the
+  // Return 1 if a prediction (of length num_labels_) correctly gives the
   // ground truth label 'label'; 0 otherwise.
   virtual int32_t ZeroOneLoss(const std::vector<float>& prediction,
+      int32_t label) const = 0;
+
+  // Return 1 if a prediction (of length num_labels_) correctly gives the
+  // ground truth label 'label'; 0 otherwise.
+  virtual int32_t TestAccuracy(const std::vector<float>& prediction,
       int32_t label) const = 0;
 
   // Compute cross entropy loss of a prediction (of length num_labels_) and the

--- a/app/mlr/src/common.hpp
+++ b/app/mlr/src/common.hpp
@@ -18,6 +18,7 @@ DECLARE_string(test_file);
 DECLARE_int32(num_train_eval);
 DECLARE_int32(num_test_eval);
 DECLARE_bool(perform_test);
+DECLARE_bool(perform_test_acc);
 DECLARE_bool(use_weight_file);
 DECLARE_string(weight_file);
 
@@ -45,9 +46,10 @@ const int32_t kColIdxLossTableZeroOneLoss = 2;    // training set
 const int32_t kColIdxLossTableEntropyLoss = 3;    // training set
 const int32_t kColIdxLossTableNumEvalTrain = 4;    // # train point eval
 const int32_t kColIdxLossTableTestZeroOneLoss = 5;
-const int32_t kColIdxLossTableNumEvalTest = 6;  // # test point eval.
-const int32_t kColIdxLossTableTime = 7;
+const int32_t kColIdxLossTableTestAccuracy = 6;
+const int32_t kColIdxLossTableNumEvalTest = 7;  // # test point eval.
+const int32_t kColIdxLossTableTime = 8;
 
-const int32_t kNumColumnsLossTable = 8;
+const int32_t kNumColumnsLossTable = 9;
 
 }  // namespace mlr

--- a/app/mlr/src/lr_sgd_solver.cpp
+++ b/app/mlr/src/lr_sgd_solver.cpp
@@ -81,6 +81,12 @@ int32_t LRSGDSolver::ZeroOneLoss(const std::vector<float>& prediction, int32_t l
     return prediction[label] >= 0.5 ? 1 : 0;
   }
 
+int32_t LRSGDSolver::TestAccuracy(const std::vector<float>& prediction, int32_t label)
+  const {
+    // prediction[0] is the probability of being in class 1
+    return prediction[label] >= 0.5 ? 0 : 1;
+  }
+
 float LRSGDSolver::CrossEntropyLoss(const std::vector<float>& prediction, int32_t label)
   const {
     CHECK_LE(prediction[label], 1);

--- a/app/mlr/src/lr_sgd_solver.hpp
+++ b/app/mlr/src/lr_sgd_solver.hpp
@@ -39,8 +39,13 @@ public:
       const petuum::ml::AbstractFeature<float>& feature) const;
 
   // Return 0 if a prediction (of length num_labels_) correctly gives the
-  // ground truth label 'label'; 0 otherwise.
+  // ground truth label 'label'; 1 otherwise.
   int32_t ZeroOneLoss(const std::vector<float>& prediction, int32_t label)
+    const;
+
+  // Return 1 if a prediction (of length num_labels_) correctly gives the
+  // ground truth label 'label'; 0 otherwise.
+  int32_t TestAccuracy(const std::vector<float>& prediction, int32_t label)
     const;
 
   // Compute cross entropy loss of a prediction (of length num_labels_) and the

--- a/app/mlr/src/mlr_engine.hpp
+++ b/app/mlr/src/mlr_engine.hpp
@@ -68,6 +68,7 @@ private:
   int32_t num_labels_;  // # of classes
   int32_t num_train_eval_;  // # of train data in each eval
   bool perform_test_;
+  bool perform_test_acc_;   // output test accuracy if perform_test_ true
   std::string read_format_; // for both train and test.
   bool feature_one_based_;  // feature starts from 1 (train and test).
   bool label_one_based_;    // label starts from 1 (train and test).

--- a/app/mlr/src/mlr_main.cpp
+++ b/app/mlr/src/mlr_main.cpp
@@ -38,6 +38,8 @@ DEFINE_int32(num_test_eval, 20, "Use the first num_test_eval test data for "
     "intermediate eval. 0 for using all. The final eval will always use all "
     "test data.");
 DEFINE_bool(perform_test, false, "Ignore test_file if true.");
+DEFINE_bool(perform_test_acc, false, "True to perform accuracy test (If "
+    "perform_test is also true.");
 DEFINE_bool(use_weight_file, false, "True to use init_weight_file as init");
 DEFINE_string(weight_file, "", "Use this file to initialize weight. "
   "Format of the file is libsvm (see SaveWeight in MLRSGDSolver).");

--- a/app/mlr/src/mlr_sgd_solver.cpp
+++ b/app/mlr/src/mlr_sgd_solver.cpp
@@ -103,12 +103,24 @@ int32_t MLRSGDSolver::ZeroOneLoss(const std::vector<float>& prediction,
   return (max_idx == label) ? 0 : 1;
 }
 
+int32_t MLRSGDSolver::TestAccuracy(const std::vector<float>& prediction,
+    int32_t label) const {
+  int max_idx = 0;
+  float max_val = prediction[0];
+  for (int i = 1; i < num_labels_; ++i) {
+    if (prediction[i] > max_val) {
+      max_val = prediction[i];
+      max_idx = i;
+    }
+  }
+  return (max_idx == label) ? 1 : 0;
+}
+
 float MLRSGDSolver::CrossEntropyLoss(const std::vector<float>& prediction,
     int32_t label) const {
   CHECK_LE(prediction[label], 1);
   return -petuum::ml::SafeLog(prediction[label]);
 }
-
 
 std::vector<float> MLRSGDSolver::Predict(
     const petuum::ml::AbstractFeature<float>& feature) const {

--- a/app/mlr/src/mlr_sgd_solver.hpp
+++ b/app/mlr/src/mlr_sgd_solver.hpp
@@ -35,8 +35,13 @@ public:
       const petuum::ml::AbstractFeature<float>& feature) const;
 
   // Return 0 if a prediction (of length num_labels_) correctly gives the
-  // ground truth label 'label'; 0 otherwise.
+  // ground truth label 'label'; 1 otherwise.
   int32_t ZeroOneLoss(const std::vector<float>& prediction, int32_t label)
+    const;
+
+  // Return 1 if a prediction (of length num_labels_) correctly gives the
+  // ground truth label 'label'; 0 otherwise.
+  int32_t TestAccuracy(const std::vector<float>& prediction, int32_t label)
     const;
 
   // Compute cross entropy loss of a prediction (of length num_labels_) and the


### PR DESCRIPTION
Sample output:

I1110 15:22:30.270061 20607 mlr_engine.cpp:83] Reading train file: /home/vagrant/josh_bosen/app/mlr/datasets/covtype.scale.train.small
I1110 15:22:30.272199 20607 data_loading.cpp:195] Read 500 instances from /home/vagrant/josh_bosen/app/mlr/datasets/covtype.scale.train.small in 0.001961 seconds.
I1110 15:22:30.272270 20607 mlr_engine.cpp:97] Reading test file: /home/vagrant/josh_bosen/app/mlr/datasets/covtype.scale.test.small
I1110 15:22:30.273124 20607 data_loading.cpp:195] Read 50 instances from /home/vagrant/josh_bosen/app/mlr/datasets/covtype.scale.test.small in 0.000839484 seconds.
NameNode is ready to accept connections!
I1110 15:22:30.277571 20607 mlr_main.cpp:140] Starting MLR with 4 threads on client 0
I1110 15:22:30.344966 20624 mlr_engine.cpp:211] Batch size: 13
I1110 15:22:31.466909 20624 mlr_engine.cpp:267] 1 10 train-0-1: 0.307692 train-entropy: 1.19601 num-train-used: 520 test-0-1: 0.240000 num-test-used: 50 test-accuracy 0.760000 time: 0.533535
I1110 15:22:32.083892 20624 mlr_engine.cpp:267] 2 20 train-0-1: 0.298077 train-entropy: 0.974686 num-train-used: 520 test-0-1: 0.240000 num-test-used: 50 test-accuracy 0.760000 time: 1.08945
I1110 15:22:32.594591 20624 mlr_engine.cpp:267] 3 30 train-0-1: 0.292308 train-entropy: 0.882558 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 1.70674
I1110 15:22:33.186537 20624 mlr_engine.cpp:267] 4 40 train-0-1: 0.286538 train-entropy: 0.830271 num-train-used: 520 test-0-1: 0.200000 num-test-used: 50 test-accuracy 0.800000 time: 2.23649
I1110 15:22:33.742911 20624 mlr_engine.cpp:267] 5 50 train-0-1: 0.284615 train-entropy: 0.795827 num-train-used: 520 test-0-1: 0.200000 num-test-used: 50 test-accuracy 0.800000 time: 2.8415
I1110 15:22:34.305946 20624 mlr_engine.cpp:267] 6 60 train-0-1: 0.288462 train-entropy: 0.770496 num-train-used: 520 test-0-1: 0.200000 num-test-used: 50 test-accuracy 0.800000 time: 3.36505
I1110 15:22:34.866078 20624 mlr_engine.cpp:267] 7 70 train-0-1: 0.284615 train-entropy: 0.751441 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 3.91783
I1110 15:22:35.431354 20624 mlr_engine.cpp:267] 8 80 train-0-1: 0.286538 train-entropy: 0.73523 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 4.51057
I1110 15:22:35.991439 20624 mlr_engine.cpp:267] 9 90 train-0-1: 0.275 train-entropy: 0.722241 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 5.08632
I1110 15:22:36.550914 20624 mlr_engine.cpp:267] 10 100 train-0-1: 0.275 train-entropy: 0.711413 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 5.64637
I1110 15:22:37.118890 20624 mlr_engine.cpp:267] 11 110 train-0-1: 0.271154 train-entropy: 0.702266 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 6.18428
I1110 15:22:37.705924 20624 mlr_engine.cpp:267] 12 120 train-0-1: 0.273077 train-entropy: 0.693844 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 6.74127
I1110 15:22:38.296916 20624 mlr_engine.cpp:267] 13 130 train-0-1: 0.273077 train-entropy: 0.686475 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 7.33911
I1110 15:22:38.821216 20624 mlr_engine.cpp:267] 14 140 train-0-1: 0.273077 train-entropy: 0.68105 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 7.94168
I1110 15:22:39.354910 20624 mlr_engine.cpp:267] 15 150 train-0-1: 0.269231 train-entropy: 0.674239 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 8.4432
I1110 15:22:39.935003 20624 mlr_engine.cpp:267] 16 160 train-0-1: 0.275 train-entropy: 0.669435 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 8.99919
I1110 15:22:40.476917 20624 mlr_engine.cpp:267] 17 170 train-0-1: 0.267308 train-entropy: 0.665552 num-train-used: 520 test-0-1: 0.220000 num-test-used: 50 test-accuracy 0.780000 time: 9.58997
I1110 15:22:41.040885 20624 mlr_engine.cpp:267] 18 180 train-0-1: 0.265385 train-entropy: 0.660297 num-train-used: 520 test-0-1: 0.200000 num-test-used: 50 test-accuracy 0.800000 time: 10.1217
I1110 15:22:41.594039 20624 mlr_engine.cpp:267] 19 190 train-0-1: 0.261538 train-entropy: 0.656976 num-train-used: 520 test-0-1: 0.200000 num-test-used: 50 test-accuracy 0.800000 time: 10.6628
I1110 15:22:42.155467 20624 mlr_engine.cpp:267] 20 200 train-0-1: 0.267308 train-entropy: 0.652918 num-train-used: 520 test-0-1: 0.200000 num-test-used: 50 test-accuracy 0.800000 time: 11.249
I1110 15:22:42.736886 20624 mlr_engine.cpp:267] 21 210 train-0-1: 0.265385 train-entropy: 0.649898 num-train-used: 520 test-0-1: 0.200000 num-test-used: 50 test-accuracy 0.800000 time: 11.8104
I1110 15:22:43.283531 20624 mlr_engine.cpp:267] 22 220 train-0-1: 0.261538 train-entropy: 0.647817 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 12.37
I1110 15:22:43.845974 20624 mlr_engine.cpp:267] 23 230 train-0-1: 0.257692 train-entropy: 0.643825 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 12.9385
I1110 15:22:44.393888 20624 mlr_engine.cpp:267] 24 240 train-0-1: 0.263462 train-entropy: 0.641002 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 13.5009
I1110 15:22:44.949021 20624 mlr_engine.cpp:267] 25 250 train-0-1: 0.253846 train-entropy: 0.639299 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 14.0273
I1110 15:22:45.492425 20624 mlr_engine.cpp:267] 26 260 train-0-1: 0.257692 train-entropy: 0.637033 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 14.604
I1110 15:22:46.065018 20624 mlr_engine.cpp:267] 27 270 train-0-1: 0.257692 train-entropy: 0.634962 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 15.1474
I1110 15:22:46.636906 20624 mlr_engine.cpp:267] 28 280 train-0-1: 0.255769 train-entropy: 0.633155 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 15.6973
I1110 15:22:47.216958 20624 mlr_engine.cpp:267] 29 290 train-0-1: 0.257692 train-entropy: 0.631067 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 16.2702
I1110 15:22:47.793886 20624 mlr_engine.cpp:267] 30 300 train-0-1: 0.255769 train-entropy: 0.628835 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 16.8393
I1110 15:22:48.341949 20624 mlr_engine.cpp:267] 31 310 train-0-1: 0.25 train-entropy: 0.627164 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 17.4065
I1110 15:22:48.893944 20624 mlr_engine.cpp:267] 32 320 train-0-1: 0.251923 train-entropy: 0.625745 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 17.9763
I1110 15:22:49.439896 20624 mlr_engine.cpp:267] 33 330 train-0-1: 0.251923 train-entropy: 0.624103 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 18.538
I1110 15:22:49.981050 20624 mlr_engine.cpp:267] 34 340 train-0-1: 0.25 train-entropy: 0.622486 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 19.0732
I1110 15:22:50.566961 20624 mlr_engine.cpp:267] 35 350 train-0-1: 0.251923 train-entropy: 0.621652 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 19.6252
I1110 15:22:51.134034 20624 mlr_engine.cpp:267] 36 360 train-0-1: 0.251923 train-entropy: 0.619673 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 20.2114
I1110 15:22:51.690950 20624 mlr_engine.cpp:267] 37 370 train-0-1: 0.25 train-entropy: 0.618021 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 20.789
I1110 15:22:52.242883 20624 mlr_engine.cpp:267] 38 380 train-0-1: 0.248077 train-entropy: 0.616838 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 21.3351
I1110 15:22:52.809403 20624 mlr_engine.cpp:267] 39 390 train-0-1: 0.248077 train-entropy: 0.61569 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 21.876
I1110 15:22:52.815505 20624 mlr_engine.cpp:300]
Epoch Batch Train-0-1 Train-Entropy Num-Train-Used Test-0-1 Test-Accuracy Num-Test-Used Time
1 10 0.307692 1.19601 520 0.240000 0.760000 50 0.533535
2 20 0.298077 0.974686 520 0.240000 0.760000 50 1.08945
3 30 0.292308 0.882558 520 0.220000 0.780000 50 1.70674
4 40 0.286538 0.830271 520 0.200000 0.800000 50 2.23649
5 50 0.284615 0.795827 520 0.200000 0.800000 50 2.8415
6 60 0.288462 0.770496 520 0.200000 0.800000 50 3.36505
7 70 0.284615 0.751441 520 0.220000 0.780000 50 3.91783
8 80 0.286538 0.73523 520 0.220000 0.780000 50 4.51057
9 90 0.275 0.722241 520 0.220000 0.780000 50 5.08632
10 100 0.275 0.711413 520 0.220000 0.780000 50 5.64637
11 110 0.271154 0.702266 520 0.220000 0.780000 50 6.18428
12 120 0.273077 0.693844 520 0.220000 0.780000 50 6.74127
13 130 0.273077 0.686475 520 0.220000 0.780000 50 7.33911
14 140 0.273077 0.68105 520 0.220000 0.780000 50 7.94168
15 150 0.269231 0.674239 520 0.220000 0.780000 50 8.4432
16 160 0.275 0.669435 520 0.220000 0.780000 50 8.99919
17 170 0.267308 0.665552 520 0.220000 0.780000 50 9.58997
18 180 0.265385 0.660297 520 0.200000 0.800000 50 10.1217
19 190 0.261538 0.656976 520 0.200000 0.800000 50 10.6628
20 200 0.267308 0.652918 520 0.200000 0.800000 50 11.249
21 210 0.265385 0.649898 520 0.200000 0.800000 50 11.8104
22 220 0.261538 0.647817 520 0.180000 0.820000 50 12.37
23 230 0.257692 0.643825 520 0.180000 0.820000 50 12.9385
24 240 0.263462 0.641002 520 0.180000 0.820000 50 13.5009
25 250 0.253846 0.639299 520 0.180000 0.820000 50 14.0273
26 260 0.257692 0.637033 520 0.180000 0.820000 50 14.604
27 270 0.257692 0.634962 520 0.180000 0.820000 50 15.1474
28 280 0.255769 0.633155 520 0.180000 0.820000 50 15.6973
29 290 0.257692 0.631067 520 0.180000 0.820000 50 16.2702
30 300 0.255769 0.628835 520 0.180000 0.820000 50 16.8393
31 310 0.25 0.627164 520 0.180000 0.820000 50 17.4065
32 320 0.251923 0.625745 520 0.180000 0.820000 50 17.9763
33 330 0.251923 0.624103 520 0.180000 0.820000 50 18.538
34 340 0.25 0.622486 520 0.180000 0.820000 50 19.0732
35 350 0.251923 0.621652 520 0.180000 0.820000 50 19.6252
36 360 0.251923 0.619673 520 0.180000 0.820000 50 20.2114
37 370 0.25 0.618021 520 0.180000 0.820000 50 20.789
38 380 0.248077 0.616838 520 0.180000 0.820000 50 21.3351
39 390 0.248077 0.61569 520 0.180000 0.820000 50 21.876
40 400 0.25 0.614718 520 0.180000 0.820000 50 22.4644
40 400 0.25 0.614718 520 0.180000 0.820000 50 22.4646
I1110 15:22:52.815529 20624 mlr_engine.cpp:301] Final eval: 40 400 train-0-1: 0.25 train-entropy: 0.614718 num-train-used: 520 test-0-1: 0.180000 num-test-used: 50 test-accuracy 0.820000 time: 22.4646
I1110 15:22:52.815980 20624 mlr_engine.cpp:450] Loss up to 40 (exclusive) is saved to /home/vagrant/josh_bosen/app/mlr/out.loss in 0.000440231
I1110 15:22:52.816341 20624 mlr_sgd_solver.cpp:172] Saved weight to /home/vagrant/josh_bosen/app/mlr/out.weight
I1110 15:22:52.817934 20607 mlr_main.cpp:152] MLR finished and shut down!